### PR TITLE
more readable railtie / engine output

### DIFF
--- a/lib/gem_bench/team.rb
+++ b/lib/gem_bench/team.rb
@@ -49,10 +49,11 @@ module GemBench
       else
         if self.starters.length > 0
           string << "\n#{GemBench::USAGE}" unless self.check_gemfile
+          string << "[GemBench] We found a Rails::Railtie or Rails::Engine in the following files. However, it is possible that there are false positives, so you may want to verify that this is the case.\n\n"
           self.starters.each do |starter|
-            string << "[GemBench] You might want to verify that #{starter} really has a Rails::Railtie or Rails::Engine.  Check these files:\n"
+            string << "\t#{starter}:\n"
             starter.stats.each do |stat|
-              string << "\t#{stat}\n"
+              string << "\t\t#{stat[0]}:#{stat[1]}\n"
             end
           end
           string << "[GemBench] If you want to check for false positives, the files to check for Railties and Engines are listed above.\n"


### PR DESCRIPTION
related to #4

example output:

```
[GemBench] We found a Rails::Railtie or Rails::Engine in the following files. However, it is possible that there are false positives, so you may want to verify that this is the case.

    activesupport v4.0.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/activesupport-3.1.12/lib/active_support/i18n_railtie.rb:146
    rack v1.5.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/rack-timeout-0.0.3/lib/rack-timeout.rb:227
    actionpack v4.0.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/actionpack-3.2.14/lib/action_controller/railtie.rb:248
    railties v4.0.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/railties-3.2.14/lib/rails/application/configuration.rb:245
    action_dispatch-gz_static v0.0.3:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/action_dispatch-gz_static-0.0.3/lib/action_dispatch/gz_railtie.rb:42
    actionmailer v4.0.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/actionmailer-3.2.14/lib/action_mailer/railtie.rb:133
    activemodel v4.0.2:
        /Users/john/.rbenv/versions/2.1.0-preview1/lib/ruby/gems/2.1.0/gems/activemodel-4.0.0/lib/active_model/railtie.rb:77
    activerecord v4.0.2:
```
