### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GemBench
+# GemBench [![Inline docs](http://inch-pages.github.io/github/pboling/gem_bench.png)](http://inch-pages.github.io/github/pboling/gem_bench)
 
 Gem: "Put me in coach!"
 You: ❨╯°□°❩╯︵┻━┻


### PR DESCRIPTION
I just added the badge you requested to your README: ![Inline docs](http://inch-pages.github.io/github/pboling/gem_bench.png)

I did not know where to put it, since there are no of the usual suspects present in this project, so I put it next to the title.

Your status page for this project is http://inch-pages.github.io/github/pboling/gem_bench
