### PR TITLE
Update docs badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GemBench [![Inline docs](http://inch-pages.github.io/github/pboling/gem_bench.png)](http://inch-pages.github.io/github/pboling/gem_bench)
+# GemBench [![Inline docs](http://inch-ci.org/github/pboling/gem_bench.png)](http://inch-ci.org/github/pboling/gem_bench)
 
 Gem: "Put me in coach!"
 You: ❨╯°□°❩╯︵┻━┻


### PR DESCRIPTION
Update the URL of the docs badge to include it from inch-ci.org instead of inch-pages.github.io (the former being the successor of the Inch Pages project).

[ci skip]
